### PR TITLE
Add options

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,13 +15,13 @@ if [ "$2" == "--setup" ] || [ "$3" == "--setup" ] || [ "$4" == "--setup" ]; then
 		./gradlew setupForge
 		
 		echo "[Akarin] Touch workspace.."
-		#\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
-		#\cp -rf "$forgebasedir/projects/Forge/.project" "$basedir/"
-		#\cp -rf "$forgebasedir/projects/Forge/.classpath" "$basedir/"
-		#\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
-		#\cp -rf "$forgebasedir/projects/Forge/Forge.iml" "$basedir/"
-		#\cp -rf "$forgebasedir/projects/Forge/Forge Client.launch" "$basedir/"
-		#\cp -rf "$forgebasedir/projects/Forge/Forge Server.launch" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/.project" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/.classpath" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/Forge.iml" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/Forge Client.launch" "$basedir/"
+		\cp -rf "$forgebasedir/projects/Forge/Forge Server.launch" "$basedir/"
 	)
 fi
 echo "[Akarin] Ready to build"
@@ -44,7 +44,7 @@ echo "[Akarin] Ready to build"
 	echo "[Akarin] Brute Forcing"
 	\cp "$basedir/changelog_new.txt" "$forgebasedir/build/"
 	echo "[Akarin] Build Forge.. (2/2)"
-	./gradlew launch4j
+	./gradlew launch4j --debug
 
 	build="$forgebasedir/build/distributions"
 	\cp -rf "$build" "$basedir/"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,11 +30,21 @@ echo "[Akarin] Ready to build"
 	\cp -rf "$basedir/jsons" "$forgebasedir/"
 	\cp -rf "$basedir/icon.ico" "$forgebasedir/"
 
-	echo "[Akarin] Touch forge.."
-	\cp -rf "$basedir/sources/server/src" "$forgebasedir/projects/Forge/"
-	
 	echo "[Akarin] Touch server.."
-	\cp -rf "$basedir/sources/forge/src" "$forgebasedir/"
+	if [ "$2" == "--delsrc" ] || [ "$3" == "--delsrc" ] || [ "$4" == "--delsrc" ]; then
+		\rm -rf "$forgebasedir/projects/Forge/src"
+		\cp -rf "$basedir/sources/server/src" "$forgebasedir/projects/Forge/"
+	else
+		\cp -rf "$basedir/sources/server/src" "$forgebasedir/projects/Forge/"
+	fi
+	
+	echo "[Akarin] Touch forge.."
+	if [ "$2" == "--delsrc" ] || [ "$3" == "--delsrc" ] || [ "$4" == "--delsrc" ]; then
+		\rm -rf "$forgebasedir/src"
+		\cp -rf "$basedir/sources/forge/src" "$forgebasedir/"
+	else
+		\cp -rf "$basedir/sources/forge/src" "$forgebasedir/"
+	fi
 
 	cd "$forgebasedir"
 	echo "[Akarin] Build Forge.. (1/2)"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,28 +31,33 @@ echo "[Akarin] Ready to build"
 	\cp -rf "$basedir/icon.ico" "$forgebasedir/"
 
 	echo "[Akarin] Touch server.."
-	if [ "$2" == "--delsrc" ] || [ "$3" == "--delsrc" ] || [ "$4" == "--delsrc" ]; then
-		\rm -rf "$forgebasedir/projects/Forge/src"
+	if [ "$2" == "--nodelsrc" ] || [ "$3" == "--nodelsrc" ] || [ "$4" == "--nodelsrc" ]; then
 		\cp -rf "$basedir/sources/server/src" "$forgebasedir/projects/Forge/"
 	else
+		\rm -rf "$forgebasedir/projects/Forge/src"
 		\cp -rf "$basedir/sources/server/src" "$forgebasedir/projects/Forge/"
 	fi
 	
 	echo "[Akarin] Touch forge.."
-	if [ "$2" == "--delsrc" ] || [ "$3" == "--delsrc" ] || [ "$4" == "--delsrc" ]; then
-		\rm -rf "$forgebasedir/src"
+	if [ "$2" == "--nodelsrc" ] || [ "$3" == "--nodelsrc" ] || [ "$4" == "--nodelsrc" ]; then
 		\cp -rf "$basedir/sources/forge/src" "$forgebasedir/"
 	else
+		\rm -rf "$forgebasedir/src"
 		\cp -rf "$basedir/sources/forge/src" "$forgebasedir/"
 	fi
 
 	cd "$forgebasedir"
 	echo "[Akarin] Build Forge.. (1/2)"
 	./gradlew genPatches
-	echo "[Akarin] Brute Forcing"
-	\cp "$basedir/changelog_new.txt" "$forgebasedir/build/"
-	echo "[Akarin] Build Forge.. (2/2)"
-	./gradlew launch4j
+	if [ "$2" == "--nobrute" ] || [ "$3" == "--nobrute" ] || [ "$4" == "--nobrute" ]; then
+		echo "[Akarin] Build Forge.. (2/2)"
+		./gradlew createExe
+	else
+		echo "[Akarin] Brute Forcing"
+		\cp "$basedir/changelog_new.txt" "$forgebasedir/build/"
+		echo "[Akarin] Build Forge.. (2/2)"
+		./gradlew createExe
+	fi
 
 	build="$forgebasedir/build/distributions"
 	\cp -rf "$build" "$basedir/"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,11 +31,9 @@ echo "[Akarin] Ready to build"
 	\cp -rf "$basedir/icon.ico" "$forgebasedir/"
 
 	echo "[Akarin] Touch forge.."
-	\rm -rf "$forgebasedir/projects/Forge/src"
 	\cp -rf "$basedir/sources/server/src" "$forgebasedir/projects/Forge/"
 	
 	echo "[Akarin] Touch server.."
-	\rm -rf "$forgebasedir/src"
 	\cp -rf "$basedir/sources/forge/src" "$forgebasedir/"
 
 	cd "$forgebasedir"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,13 +15,13 @@ if [ "$2" == "--setup" ] || [ "$3" == "--setup" ] || [ "$4" == "--setup" ]; then
 		./gradlew setupForge
 		
 		echo "[Akarin] Touch workspace.."
-		\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
-		\cp -rf "$forgebasedir/projects/Forge/.project" "$basedir/"
-		\cp -rf "$forgebasedir/projects/Forge/.classpath" "$basedir/"
-		\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
-		\cp -rf "$forgebasedir/projects/Forge/Forge.iml" "$basedir/"
-		\cp -rf "$forgebasedir/projects/Forge/Forge Client.launch" "$basedir/"
-		\cp -rf "$forgebasedir/projects/Forge/Forge Server.launch" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/.project" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/.classpath" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/.settings" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/Forge.iml" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/Forge Client.launch" "$basedir/"
+		#\cp -rf "$forgebasedir/projects/Forge/Forge Server.launch" "$basedir/"
 	)
 fi
 echo "[Akarin] Ready to build"
@@ -44,7 +44,7 @@ echo "[Akarin] Ready to build"
 	echo "[Akarin] Brute Forcing"
 	\cp "$basedir/changelog_new.txt" "$forgebasedir/build/"
 	echo "[Akarin] Build Forge.. (2/2)"
-	./gradlew launch4j --debug
+	./gradlew launch4j
 
 	build="$forgebasedir/build/distributions"
 	\cp -rf "$build" "$basedir/"


### PR DESCRIPTION
--nodelsrc and --nobrute
nodelsrc option just doesn't delete forge's source. Useful in some cases.
nobrute doesn't brute force, useful for when testing for it specifically.

oh and changed the launch4j to createExe since the compiler always screams of it being deprecated.